### PR TITLE
feat: added template for java binary builder

### DIFF
--- a/builders/binary/java_binary_builder.py
+++ b/builders/binary/java_binary_builder.py
@@ -6,6 +6,28 @@ import subprocess
 from monitoring.logger import Logger
 from builders.plugins.plugin_interface import ArtifactBuilder
 
+BUILD_SYSTEMS = {
+    "maven": {
+        "files": ["pom.xml"],
+        "command": ["mvn", "-DskipTests", "clean", "package"],
+        "build_dir": "target",
+        "docker_image": "maven:3.9-eclipse-temurin-17",
+    },
+    "gradle": {
+        "files": ["build.gradle", "build.gradle.kts"],
+        "command": ["gradle", "clean", "build", "-x", "test"],
+        "build_dir": os.path.join("build", "libs"),
+        "docker_image": "gradle:8.7-jdk17",
+    },
+}
+
+
+def detect_build_system(repo_path: str):
+    for system, config in BUILD_SYSTEMS.items():
+        for f in config["files"]:
+            if os.path.exists(os.path.join(repo_path, f)):
+                return system, config
+    return None, None
 
 class JavaBinaryBuilder(ArtifactBuilder):
     def __init__(self):

--- a/builders/binary/java_binary_builder.py
+++ b/builders/binary/java_binary_builder.py
@@ -1,0 +1,108 @@
+#  Copyright Contributors to the Mainframe Software Hub for Linux Project.
+#  SPDX-License-Identifier: Apache-2.0
+
+import os
+import subprocess
+from monitoring.logger import Logger
+from builders.plugins.plugin_interface import ArtifactBuilder
+
+
+class JavaBinaryBuilder(ArtifactBuilder):
+    def __init__(self):
+        self.logger = Logger()
+
+    def build(self, repo_path: str, repo_gh_name: str, artifact: dict) -> str:
+        repo_name = os.path.basename(repo_path)
+        version = artifact.get("version", "1.0")
+
+        output_path = f"{repo_path}/build/{repo_gh_name}_{version}.jar"
+
+        docker_image = artifact.get("docker_image", "maven:3.9-eclipse-temurin-17")
+
+        try:
+            os.makedirs("build", exist_ok=True)
+
+            self.logger.info(f"Building Java artifact for {repo_gh_name}")
+
+            pom_path = os.path.join(repo_path, "pom.xml")
+            gradle_path = os.path.join(repo_path, "build.gradle")
+            gradle_kts_path = os.path.join(repo_path, "build.gradle.kts")
+
+            is_maven = os.path.exists(pom_path)
+            is_gradle = os.path.exists(gradle_path) or os.path.exists(gradle_kts_path)
+
+            if not is_maven and not is_gradle:
+                raise RuntimeError(
+                    f"No supported Java build file found in {repo_path}. "
+                    f"Expected pom.xml or build.gradle(.kts)."
+                )
+
+            if is_maven:
+                cmd = ["mvn", "-DskipTests", "clean", "package"]
+
+                expected_build_dir = os.path.join(repo_path, "target")
+
+            else:
+                cmd = ["gradle", "clean", "build", "-x", "test"]
+
+                expected_build_dir = os.path.join(repo_path, "build", "libs")
+
+            subprocess.run(
+                [
+                    "docker", "run", "--rm",
+                    "-v", f"{repo_path}:{repo_path}",
+                    "-v", f"{repo_path}:/app",
+                    "-w", "/app",
+                    docker_image,
+                ] + cmd,
+                check=True
+            )
+
+            jar_candidates = []
+            if os.path.isdir(expected_build_dir):
+                for f in os.listdir(expected_build_dir):
+                    if f.endswith(".jar"):
+                        jar_candidates.append(os.path.join(expected_build_dir, f))
+
+            if not jar_candidates:
+                raise RuntimeError(
+                    f"No JAR produced. Looked in: {expected_build_dir}. "
+                    f"TODO: Confirm build output paths / packaging."
+                )
+
+            chosen_jar = jar_candidates[0]
+
+            subprocess.run(["cp", chosen_jar, output_path], check=True)
+
+            self.logger.info(f"Built Java artifact at {output_path}")
+            return output_path
+
+        except subprocess.CalledProcessError as e:
+            self.logger.error(f"Failed to build Java artifact for {repo_name}: {str(e)}")
+            raise
+
+    def publish(self, artifact_path: str, repo_gh_name: str, artifact: dict) -> None:
+        from lib.checksum import generate_checksum
+
+        checksum = generate_checksum(artifact_path)
+        version = artifact.get("version", "1.0")
+
+        self.logger.info(f"Publishing {artifact_path} with checksum {checksum} for {repo_gh_name}")
+
+        try:
+            subprocess.run(
+                [
+                    "gh", "release", "create", f"v{version}",
+                    "--title", f"Version {version}",
+                    "--generate-notes",
+                    artifact_path,
+                    f"{artifact_path}.sha256",
+                ],
+                cwd=os.path.dirname(artifact_path),
+                check=True
+            )
+            self.logger.info(f"Published {artifact_path} to GitHub Releases")
+
+        except subprocess.CalledProcessError as e:
+            self.logger.error(f"Failed to publish {artifact_path}: {str(e)}")
+            raise


### PR DESCRIPTION
## Summary

This PR introduces a **JavaBinaryBuilder** plugin following the same patterns and lifecycle as the existing `GoBinaryBuilder`.
The goal is to support Java repositories by producing a versioned `.jar` artifact that can be uploaded to GitHub Releases in a consistent way.

### Currently implemented things
- Auto-detect build system: Maven (`pom.xml`) or Gradle (`build.gradle` / `build.gradle.kts`)

- JAR is the standard packaged output for Java projects and is the closest equivalent “release artifact” for this builder system, so  the “binary” for Java is treated as a **JAR** (not a native ELF executable).

- Builds are executed inside Docker containers using the repo mounted into `/app`, as it ensures reproducible builds across dev machines + CI environments and follows the same execution model as the `Go builder`. 

- the default Docker image is `Maven + Temurin JDK 17` as Java 17 is a stable LTS choice and Maven is common. see: https://hub.docker.com/layers/library/maven/3.9-eclipse-temurin-17/images/sha256-078164c49b664077cd330ad6cd367eb3baa5188380d68c82bf364c04c11748e9

### Questions before i finalize the PR

- What should "Java binary" mean for this system... plain jar or fat/uber jar
- when multiple jars exist, should we prioritize shaded jars / Spring Boot jars?

So, Once the above decisions are confirmed, I will update the builder into a finalized implementation and push the changes.
PS, I havent yet manually tested this on a java project, but will do thst once the code is ready.

cc @pleia2 @rposts 