### PR TITLE
fix: fixed preexisting tests ci failure

### DIFF
--- a/builders/script/loz_script_builder.py
+++ b/builders/script/loz_script_builder.py
@@ -78,18 +78,30 @@ class ScriptBuilder(ArtifactBuilder):
         checksum = generate_checksum(artifact_path)
         art_dirname = os.path.dirname(artifact_path)
         version = artifact.get('version', '1.0')
-        artifact_path_with_distro = f"{repo_gh_name}-{version}-linux-s390x.tar.gz"
-        distro_details = "ubuntu-22.04" # Default
 
-        try:
-           with open(f"{art_dirname}/.distro_zab.txt", 'r') as file:
-               distro_details = file.readline().strip()
-               artifact_path_with_distro = f"{art_dirname}/{repo_gh_name}-{version}-{distro_details}-linux-s390x.tar.gz"
-               # Rename atrifacts prior to publishing to indicate the distro it was built on
-               os.rename(artifact_path, artifact_path_with_distro)
-               os.rename(f"{artifact_path}.sha256", f"{artifact_path_with_distro}.sha256")
-        except Exception as e:
-           print(f"An error occurred: {e}")
+        # Only apply a distro suffix to artifact names when .distro_zab.txt
+        # is present AND non-empty. Otherwise keep original names so that
+        # the tarball and the companion rpm/deb stay consistent.
+        artifact_path_with_distro = artifact_path
+        distro_details = None
+        distro_file = os.path.join(art_dirname, ".distro_zab.txt")
+        if os.path.exists(distro_file):
+            try:
+                with open(distro_file, 'r') as file:
+                    distro_details = file.readline().strip() or None
+                if distro_details:
+                    artifact_path_with_distro = os.path.join(
+                        art_dirname,
+                        f"{repo_gh_name}-{version}-{distro_details}-linux-s390x.tar.gz",
+                    )
+                    os.rename(artifact_path, artifact_path_with_distro)
+                    sha256_src = f"{artifact_path}.sha256"
+                    if os.path.exists(sha256_src):
+                        os.rename(sha256_src, f"{artifact_path_with_distro}.sha256")
+            except Exception as e:
+                self.logger.warning(f"Failed to apply distro naming: {e}")
+                distro_details = None
+                artifact_path_with_distro = artifact_path
 
         rpm_path = f"{art_dirname}/{repo_gh_name}-{version}-linux-s390x.rpm" if os.path.exists(f"{art_dirname}/{repo_gh_name}-{version}-linux-s390x.rpm") else None
         deb_path = f"{art_dirname}/{repo_gh_name}-{version}-linux-s390x.deb" if os.path.exists(f"{art_dirname}/{repo_gh_name}-{version}-linux-s390x.deb") else None
@@ -102,18 +114,22 @@ class ScriptBuilder(ArtifactBuilder):
                 check=True
             )
             if rpm_path is not None:
-                rpm_path_with_distro = f"{art_dirname}/{repo_gh_name}-{version}-{distro_details}-linux-s390x.rpm"
-                os.rename(rpm_path, rpm_path_with_distro)
+                rpm_upload_path = rpm_path
+                if distro_details:
+                    rpm_upload_path = f"{art_dirname}/{repo_gh_name}-{version}-{distro_details}-linux-s390x.rpm"
+                    os.rename(rpm_path, rpm_upload_path)
                 subprocess.run(
-                    ["gh", "release", "upload", f"v{version}", rpm_path_with_distro],
+                    ["gh", "release", "upload", f"v{version}", rpm_upload_path],
                     cwd=os.path.dirname(artifact_path_with_distro),
                     check=True
                 )
             if deb_path is not None:
-                deb_path_with_distro = f"{art_dirname}/{repo_gh_name}-{version}-{distro_details}-linux-s390x.deb"
-                os.rename(deb_path, deb_path_with_distro)
+                deb_upload_path = deb_path
+                if distro_details:
+                    deb_upload_path = f"{art_dirname}/{repo_gh_name}-{version}-{distro_details}-linux-s390x.deb"
+                    os.rename(deb_path, deb_upload_path)
                 subprocess.run(
-                    ["gh", "release", "upload", f"v{version}", deb_path_with_distro],
+                    ["gh", "release", "upload", f"v{version}", deb_upload_path],
                     cwd=os.path.dirname(artifact_path_with_distro),
                     check=True
                 )

--- a/tests/test_script_builder.py
+++ b/tests/test_script_builder.py
@@ -307,6 +307,103 @@ class TestScriptBuilder:
         assert os.path.normpath(deb_path) == uploaded_file
 
     @patch('lib.checksum.generate_checksum')
+    def test_publish_with_distro_marker_renames_tarball(self, mock_checksum, temp_repo_dir, mocker):
+        """When .distro_zab.txt is present, the tarball is renamed with distro suffix before publishing."""
+        artifact_path = os.path.join(temp_repo_dir, "test-app-1.0.0-linux-s390x.tar.gz")
+        sha256_path = f"{artifact_path}.sha256"
+        with open(artifact_path, "w") as f:
+            f.write("fake tarball")
+        with open(sha256_path, "w") as f:
+            f.write("abc123")
+        with open(os.path.join(temp_repo_dir, ".distro_zab.txt"), "w") as f:
+            f.write("ubuntu-22.04\n")
+
+        mock_checksum.return_value = "abc123"
+        mock_run = mocker.patch('subprocess.run')
+
+        builder = ScriptBuilder()
+        builder.publish(artifact_path, "test-app", {"version": "1.0.0"})
+
+        renamed_tarball = os.path.join(
+            temp_repo_dir, "test-app-1.0.0-ubuntu-22.04-linux-s390x.tar.gz"
+        )
+        assert os.path.exists(renamed_tarball)
+        assert os.path.exists(f"{renamed_tarball}.sha256")
+        assert not os.path.exists(artifact_path)
+
+        mock_run.assert_called_once()
+        create_call_args = mock_run.call_args[0][0]
+        assert renamed_tarball in create_call_args
+        assert f"{renamed_tarball}.sha256" in create_call_args
+
+    @patch('lib.checksum.generate_checksum')
+    def test_publish_with_distro_marker_renames_rpm_and_deb(self, mock_checksum, temp_repo_dir, mocker):
+        """RPM and DEB companion artifacts also get renamed with the distro suffix when the marker is present."""
+        artifact_path = os.path.join(temp_repo_dir, "test-app-1.0.0-linux-s390x.tar.gz")
+        rpm_path = os.path.join(temp_repo_dir, "test-app-1.0.0-linux-s390x.rpm")
+        deb_path = os.path.join(temp_repo_dir, "test-app-1.0.0-linux-s390x.deb")
+        with open(artifact_path, "w") as f:
+            f.write("fake tarball")
+        with open(f"{artifact_path}.sha256", "w") as f:
+            f.write("abc123")
+        with open(rpm_path, "w") as f:
+            f.write("fake rpm")
+        with open(deb_path, "w") as f:
+            f.write("fake deb")
+        with open(os.path.join(temp_repo_dir, ".distro_zab.txt"), "w") as f:
+            f.write("ubuntu-22.04")
+
+        mock_checksum.return_value = "abc123"
+        mock_run = mocker.patch('subprocess.run')
+
+        builder = ScriptBuilder()
+        builder.publish(artifact_path, "test-app", {"version": "1.0.0"})
+
+        expected_rpm = os.path.join(
+            temp_repo_dir, "test-app-1.0.0-ubuntu-22.04-linux-s390x.rpm"
+        )
+        expected_deb = os.path.join(
+            temp_repo_dir, "test-app-1.0.0-ubuntu-22.04-linux-s390x.deb"
+        )
+        assert os.path.exists(expected_rpm)
+        assert os.path.exists(expected_deb)
+        assert not os.path.exists(rpm_path)
+        assert not os.path.exists(deb_path)
+
+        assert mock_run.call_count == 3
+        rpm_upload_args = mock_run.call_args_list[1][0][0]
+        deb_upload_args = mock_run.call_args_list[2][0][0]
+        assert "upload" in rpm_upload_args
+        assert os.path.normpath(rpm_upload_args[-1]) == os.path.normpath(expected_rpm)
+        assert "upload" in deb_upload_args
+        assert os.path.normpath(deb_upload_args[-1]) == os.path.normpath(expected_deb)
+
+    @patch('lib.checksum.generate_checksum')
+    def test_publish_empty_distro_marker_falls_back_to_plain_names(self, mock_checksum, temp_repo_dir, mocker):
+        """An empty .distro_zab.txt should NOT apply any distro suffix."""
+        artifact_path = os.path.join(temp_repo_dir, "test-app-1.0.0-linux-s390x.tar.gz")
+        rpm_path = os.path.join(temp_repo_dir, "test-app-1.0.0-linux-s390x.rpm")
+        with open(artifact_path, "w") as f:
+            f.write("fake tarball")
+        with open(rpm_path, "w") as f:
+            f.write("fake rpm")
+        with open(os.path.join(temp_repo_dir, ".distro_zab.txt"), "w") as f:
+            f.write("")
+
+        mock_checksum.return_value = "abc123"
+        mock_run = mocker.patch('subprocess.run')
+
+        builder = ScriptBuilder()
+        builder.publish(artifact_path, "test-app", {"version": "1.0.0"})
+
+        assert os.path.exists(artifact_path)
+        assert os.path.exists(rpm_path)
+
+        assert mock_run.call_count == 2
+        rpm_upload_args = mock_run.call_args_list[1][0][0]
+        assert os.path.normpath(rpm_upload_args[-1]) == os.path.normpath(rpm_path)
+
+    @patch('lib.checksum.generate_checksum')
     def test_publish_subprocess_error(self, mock_checksum, temp_repo_dir, mocker):
         """Test publish handles subprocess errors gracefully."""
         artifact_path = os.path.join(temp_repo_dir, "test-app-1.0.0-linux-s390x.tar.gz")


### PR DESCRIPTION
The two failing tests (`test_publish_with_rpm` / `test_publish_with_deb`) were because of semantic drift: while PR #4 was open, `main` gained commits (`1e27efd`, `e299ea6`) that made `ScriptBuilder.publish()` stamp a distro suffix like `ubuntu-22.04` into every artifact name before upload, and that change had a bug where `distro_details` stayed at its hard-coded default when `.distro_zab.txt` was missing. So in CI (which never creates that file), the tarball kept its original name but the RPM/DEB got uploaded as `test-app-1.0.0-ubuntu-22.04-linux-s390x.{rpm,deb}`, while the tests still asserted the old non-distro names, a mismatch that only surfaced once the PR was merged and CI ran against the combined code.
